### PR TITLE
Add auth (register/login) and tasks CRUD UI with navigation flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,8 @@ app.use(helmet());
 app.use(cors());
 app.use(xss());
 
+app.use(express.static("public"));
+
 // routes
 app.use("/api/v1/auth", authRouter);
 app.use("/api/v1/tasks", authenticateUser, taskRouter);

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -54,7 +54,7 @@ export const handleAddEdit = () => {
 
             title.value = "";
             status.value = "";
-            recurrence.value = "pending";
+            recurrence.value = "";
             showTasks();
           } else {
             message.textContent = data.msg;
@@ -73,7 +73,7 @@ export const showAddEdit = async (taskId) => {
   if (!taskId) {
     title.value = "";
     status.value = "";
-    recurrence.value = "pending";
+    recurrence.value = "";
     addingTask.textContent = "add";
     message.textContent = "";
 

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -64,6 +64,9 @@ export const handleAddEdit = () => {
           message.textContent = "A communication error occurred.";
         }
         enableInput(true);
+      } else if (e.target === editCancel) {
+        message.textContent = "";
+        showTasks();
       }
     }
   });

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -15,17 +15,6 @@ export const handleAddEdit = () => {
   addingTask = document.getElementById("adding-task");
   const editCancel = document.getElementById("edit-cancel");
 
-  //   addEditDiv.addEventListener("click", (e) => {
-  //     if (inputEnabled && e.target.nodeName === "BUTTON") {
-  //       if (e.target === addingTask) {
-  //         showTasks();
-  //       } else if (e.target === editCancel) {
-  //         showTasks();
-  //       }
-  //     }
-  //   });
-  // };
-
   addEditDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === addingTask) {
@@ -49,7 +38,6 @@ export const handleAddEdit = () => {
 
           const data = await response.json();
           if (response.status === 201) {
-            // 201 indicates a successful create
             message.textContent = "The task entry was created.";
 
             title.value = "";
@@ -74,7 +62,48 @@ export const handleAddEdit = () => {
   });
 };
 
-export const showAddEdit = (task) => {
-  message.textContent = "";
-  setDiv(addEditDiv);
+export const showAddEdit = async (taskId) => {
+  if (!taskId) {
+    title.value = "";
+    status.value = "";
+    recurrence.value = "pending";
+    addingTask.textContent = "add";
+    message.textContent = "";
+
+    setDiv(addEditDiv);
+  } else {
+    enableInput(false);
+
+    try {
+      const response = await fetch(`/api/v1/tasks/${taskId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const data = await response.json();
+      if (response.status === 200) {
+        title.value = data.task.title;
+        status.value = data.task.status;
+        recurrence.value = data.task.recurrence;
+        addingTask.textContent = "update";
+        message.textContent = "";
+        addEditDiv.dataset.id = taskId;
+
+        setDiv(addEditDiv);
+      } else {
+        // might happen if the list has been updated since last display
+        message.textContent = "The tasks entry was not found";
+        showTasks();
+      }
+    } catch (err) {
+      console.log(err);
+      message.textContent = "A communications error has occurred.";
+      showTasks();
+    }
+
+    enableInput(true);
+  }
 };

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -1,0 +1,33 @@
+import { enableInput, inputEnabled, message, setDiv, token } from "./index.js";
+import { showTasks } from "./tasks.js";
+
+let addEditDiv = null;
+let company = null;
+let title = null;
+let status = null;
+let recurrence = null;
+let addingTask = null;
+
+export const handleAddEdit = () => {
+  addEditDiv = document.getElementById("edit-task");
+  company = document.getElementById("title");
+  status = document.getElementById("status");
+  recurrence = document.getElementById("recurrence");
+  addingTask = document.getElementById("adding-task");
+  const editCancel = document.getElementById("edit-cancel");
+
+  addEditDiv.addEventListener("click", (e) => {
+    if (inputEnabled && e.target.nodeName === "BUTTON") {
+      if (e.target === addingTask) {
+        showTasks();
+      } else if (e.target === editCancel) {
+        showTasks();
+      }
+    }
+  });
+};
+
+export const showAddEdit = (task) => {
+  message.textContent = "";
+  setDiv(addEditDiv);
+};

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -15,11 +15,59 @@ export const handleAddEdit = () => {
   addingTask = document.getElementById("adding-task");
   const editCancel = document.getElementById("edit-cancel");
 
-  addEditDiv.addEventListener("click", (e) => {
+  //   addEditDiv.addEventListener("click", (e) => {
+  //     if (inputEnabled && e.target.nodeName === "BUTTON") {
+  //       if (e.target === addingTask) {
+  //         showTasks();
+  //       } else if (e.target === editCancel) {
+  //         showTasks();
+  //       }
+  //     }
+  //   });
+  // };
+
+  addEditDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === addingTask) {
-        showTasks();
+        enableInput(false);
+
+        let method = "POST";
+        let url = "/api/v1/tasks";
+        try {
+          const response = await fetch(url, {
+            method: method,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              title: title.value,
+              status: status.value,
+              recurrence: recurrence.value,
+            }),
+          });
+
+          const data = await response.json();
+          if (response.status === 201) {
+            // 201 indicates a successful create
+            message.textContent = "The task entry was created.";
+
+            title.value = "";
+            status.value = "";
+            recurrence.value = "never";
+
+            showTasks();
+          } else {
+            message.textContent = data.msg;
+          }
+        } catch (err) {
+          console.log(err);
+          message.textContent = "A communication error occurred.";
+        }
+
+        enableInput(true);
       } else if (e.target === editCancel) {
+        message.textContent = "";
         showTasks();
       }
     }

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -2,7 +2,6 @@ import { enableInput, inputEnabled, message, setDiv, token } from "./index.js";
 import { showTasks } from "./tasks.js";
 
 let addEditDiv = null;
-let company = null;
 let title = null;
 let status = null;
 let recurrence = null;
@@ -10,7 +9,7 @@ let addingTask = null;
 
 export const handleAddEdit = () => {
   addEditDiv = document.getElementById("edit-task");
-  company = document.getElementById("title");
+  title = document.getElementById("title");
   status = document.getElementById("status");
   recurrence = document.getElementById("recurrence");
   addingTask = document.getElementById("adding-task");

--- a/public/addEdit.js
+++ b/public/addEdit.js
@@ -22,6 +22,12 @@ export const handleAddEdit = () => {
 
         let method = "POST";
         let url = "/api/v1/tasks";
+
+        if (addingTask.textContent === "update") {
+          method = "PATCH";
+          url = `/api/v1/tasks/${addEditDiv.dataset.id}`;
+        }
+
         try {
           const response = await fetch(url, {
             method: method,
@@ -37,13 +43,18 @@ export const handleAddEdit = () => {
           });
 
           const data = await response.json();
-          if (response.status === 201) {
-            message.textContent = "The task entry was created.";
+          if (response.status === 200 || response.status === 201) {
+            if (response.status === 200) {
+              // a 200 is expected for a successful update
+              message.textContent = "The task entry was updated.";
+            } else {
+              // a 201 is expected for a successful create
+              message.textContent = "The task entry was created.";
+            }
 
             title.value = "";
             status.value = "";
-            recurrence.value = "never";
-
+            recurrence.value = "pending";
             showTasks();
           } else {
             message.textContent = data.msg;
@@ -52,11 +63,7 @@ export const handleAddEdit = () => {
           console.log(err);
           message.textContent = "A communication error occurred.";
         }
-
         enableInput(true);
-      } else if (e.target === editCancel) {
-        message.textContent = "";
-        showTasks();
       }
     }
   });

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Task List</title>
+  </head>
+
+  <body>
+    <h1>Task List</h1>
+    <hr />
+    <p id="message"></p>
+    <hr />
+
+    <div id="login-register" style="display: none">
+      <button type="button" id="login">login</button>
+      <button type="button" id="register">register</button>
+    </div>
+
+    <div id="login-div" style="display: none">
+      <form>
+        <div>
+          <label for="email">email:</label> <input type="email" id="email" />
+        </div>
+
+        <div>
+          <label for="password">password:</label>
+          <input type="password" id="password" />
+        </div>
+
+        <button type="button" id="login-button">login</button>
+        <button type="button" id="login-cancel">cancel</button>
+      </form>
+    </div>
+
+    <div id="register-div" style="display: none">
+      <form>
+        <div>
+          <label for="name">name:</label> <input type="text" id="name" />
+        </div>
+        <div>
+          <label for="email1">email:</label> <input type="email" id="email1" />
+        </div>
+        <div>
+          <label for="password1">password:</label>
+          <input type="password" id="password1" />
+        </div>
+        <div>
+          <label for="password2">verify password:</label>
+          <input type="password" id="password2" />
+        </div>
+        <button type="button" id="register-button">register</button>
+        <button type="button" id="register-cancel">cancel</button>
+      </form>
+    </div>
+
+    <div id="tasks" style="display: none">
+      <p id="tasks-message"></p>
+      <table id="tasks-table">
+        <tr id="tasks-table-header">
+          <th>Title</th>
+          <th>Status</th>
+          <th>Recurrence</th>
+          <th colspan="2"></th>
+        </tr>
+      </table>
+      <button type="button" id="add-task">add task</button>
+      <button type="button" id="logoff">log off</button>
+    </div>
+
+    <div id="edit-task" style="display: none">
+      <form>
+        <div>
+          <label for="title">Title:</label>
+          <input type="text" id="title" />
+        </div>
+
+        <div>
+          <label for="status">Status:</label>
+          <select id="status">
+            <option value="todo">todo</option>
+            <option value="in-progress">in-progress</option>
+            <option value="done">done</option>
+            <option value="skipped">skipped</option>
+          </select>
+        </div>
+
+        <div>
+          <label for="recurrence">Recurrence:</label>
+          <select id="recurrence">
+            <option value="never">never</option>
+            <option value="daily">daily</option>
+            <option value="weekly">weekly</option>
+          </select>
+        </div>
+
+        <button type="button" id="adding-task">add</button>
+        <button type="button" id="edit-cancel">cancel</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -99,5 +99,7 @@
         <button type="button" id="edit-cancel">cancel</button>
       </form>
     </div>
+
+    <script src="./index.js" type="module"></script>
   </body>
 </html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,0 +1,48 @@
+let activeDiv = null;
+export const setDiv = (newDiv) => {
+  if (newDiv != activeDiv) {
+    if (activeDiv) {
+      activeDiv.style.display = "none";
+    }
+    newDiv.style.display = "block";
+    activeDiv = newDiv;
+  }
+};
+
+export let inputEnabled = true;
+export const enableInput = (state) => {
+  inputEnabled = state;
+};
+
+export let token = null;
+export const setToken = (value) => {
+  token = value;
+  if (value) {
+    localStorage.setItem("token", value);
+  } else {
+    localStorage.removeItem("token");
+  }
+};
+
+export let message = null;
+
+import { showJobs, handleJobs } from "./jobs.js";
+import { showLoginRegister, handleLoginRegister } from "./loginRegister.js";
+import { handleLogin } from "./login.js";
+import { handleAddEdit } from "./addEdit.js";
+import { handleRegister } from "./register.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  token = localStorage.getItem("token");
+  message = document.getElementById("message");
+  handleLoginRegister();
+  handleLogin();
+  handleJobs();
+  handleRegister();
+  handleAddEdit();
+  if (token) {
+    showJobs();
+  } else {
+    showLoginRegister();
+  }
+});

--- a/public/index.js
+++ b/public/index.js
@@ -26,7 +26,7 @@ export const setToken = (value) => {
 
 export let message = null;
 
-import { showJobs, handleJobs } from "./jobs.js";
+import { showTasks, handleTasks } from "./tasks.js";
 import { showLoginRegister, handleLoginRegister } from "./loginRegister.js";
 import { handleLogin } from "./login.js";
 import { handleAddEdit } from "./addEdit.js";
@@ -37,11 +37,11 @@ document.addEventListener("DOMContentLoaded", () => {
   message = document.getElementById("message");
   handleLoginRegister();
   handleLogin();
-  handleJobs();
+  handleTasks();
   handleRegister();
   handleAddEdit();
   if (token) {
-    showJobs();
+    showTasks();
   } else {
     showLoginRegister();
   }

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,38 @@
+import {
+  inputEnabled,
+  setDiv,
+  token,
+  message,
+  enableInput,
+  setToken,
+} from "./index.js";
+import { showLoginRegister } from "./loginRegister.js";
+import { showJobs } from "./jobs.js";
+
+let loginDiv = null;
+let email = null;
+let password = null;
+
+export const handleLogin = () => {
+  loginDiv = document.getElementById("login-div");
+  email = document.getElementById("email");
+  password = document.getElementById("password");
+  const loginButton = document.getElementById("login-button");
+  const loginCancel = document.getElementById("login-cancel");
+
+  loginDiv.addEventListener("click", (e) => {
+    if (inputEnabled && e.target.nodeName === "BUTTON") {
+      if (e.target === loginButton) {
+        showJobs();
+      } else if (e.target === loginCancel) {
+        showLoginRegister();
+      }
+    }
+  });
+};
+
+export const showLogin = () => {
+  email.value = null;
+  password.value = null;
+  setDiv(loginDiv);
+};

--- a/public/login.js
+++ b/public/login.js
@@ -1,3 +1,42 @@
+// import {
+//   inputEnabled,
+//   setDiv,
+//   token,
+//   message,
+//   enableInput,
+//   setToken,
+// } from "./index.js";
+// import { showLoginRegister } from "./loginRegister.js";
+// import { showTasks } from "./tasks.js";
+
+// let loginDiv = null;
+// let email = null;
+// let password = null;
+
+// export const handleLogin = () => {
+//   loginDiv = document.getElementById("login-div");
+//   email = document.getElementById("email");
+//   password = document.getElementById("password");
+//   const loginButton = document.getElementById("login-button");
+//   const loginCancel = document.getElementById("login-cancel");
+
+//   loginDiv.addEventListener("click", (e) => {
+//     if (inputEnabled && e.target.nodeName === "BUTTON") {
+//       if (e.target === loginButton) {
+//         showTasks();
+//       } else if (e.target === loginCancel) {
+//         showLoginRegister();
+//       }
+//     }
+//   });
+// };
+
+// export const showLogin = () => {
+//   email.value = null;
+//   password.value = null;
+//   setDiv(loginDiv);
+// };
+
 import {
   inputEnabled,
   setDiv,
@@ -7,7 +46,7 @@ import {
   setToken,
 } from "./index.js";
 import { showLoginRegister } from "./loginRegister.js";
-import { showJobs } from "./jobs.js";
+import { showTasks } from "./tasks.js";
 
 let loginDiv = null;
 let email = null;
@@ -20,11 +59,44 @@ export const handleLogin = () => {
   const loginButton = document.getElementById("login-button");
   const loginCancel = document.getElementById("login-cancel");
 
-  loginDiv.addEventListener("click", (e) => {
+  loginDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === loginButton) {
-        showJobs();
+        enableInput(false);
+
+        try {
+          const response = await fetch("/api/v1/auth/login", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              email: email.value,
+              password: password.value,
+            }),
+          });
+
+          const data = await response.json();
+          if (response.status === 200) {
+            message.textContent = `Login successful.  Welcome ${data.user.name}`;
+            setToken(data.token);
+
+            email.value = "";
+            password.value = "";
+
+            showTasks();
+          } else {
+            message.textContent = data.msg;
+          }
+        } catch (err) {
+          console.error(err);
+          message.textContent = "A communications error occurred.";
+        }
+
+        enableInput(true);
       } else if (e.target === loginCancel) {
+        email.value = "";
+        password.value = "";
         showLoginRegister();
       }
     }

--- a/public/loginRegister.js
+++ b/public/loginRegister.js
@@ -1,0 +1,25 @@
+import { inputEnabled, setDiv } from "./index.js";
+import { showLogin } from "./login.js";
+import { showRegister } from "./register.js";
+
+let loginRegisterDiv = null;
+
+export const handleLoginRegister = () => {
+  loginRegisterDiv = document.getElementById("login-register");
+  const login = document.getElementById("login");
+  const register = document.getElementById("register");
+
+  loginRegisterDiv.addEventListener("click", (e) => {
+    if (inputEnabled && e.target.nodeName === "BUTTON") {
+      if (e.target === login) {
+        showLogin();
+      } else if (e.target === register) {
+        showRegister();
+      }
+    }
+  });
+};
+
+export const showLoginRegister = () => {
+  setDiv(loginRegisterDiv);
+};

--- a/public/register.js
+++ b/public/register.js
@@ -1,0 +1,43 @@
+import {
+  inputEnabled,
+  setDiv,
+  message,
+  token,
+  enableInput,
+  setToken,
+} from "./index.js";
+import { showLoginRegister } from "./loginRegister.js";
+import { showJobs } from "./jobs.js";
+
+let registerDiv = null;
+let name = null;
+let email1 = null;
+let password1 = null;
+let password2 = null;
+
+export const handleRegister = () => {
+  registerDiv = document.getElementById("register-div");
+  name = document.getElementById("name");
+  email1 = document.getElementById("email1");
+  password1 = document.getElementById("password1");
+  password2 = document.getElementById("password2");
+  const registerButton = document.getElementById("register-button");
+  const registerCancel = document.getElementById("register-cancel");
+
+  registerDiv.addEventListener("click", (e) => {
+    if (inputEnabled && e.target.nodeName === "BUTTON") {
+      if (e.target === registerButton) {
+        showJobs();
+      } else if (e.target === registerCancel) {
+        showLoginRegister();
+      }
+    }
+  });
+};
+
+export const showRegister = () => {
+  email1.value = null;
+  password1.value = null;
+  password2.value = null;
+  setDiv(registerDiv);
+};

--- a/public/register.js
+++ b/public/register.js
@@ -7,7 +7,7 @@ import {
   setToken,
 } from "./index.js";
 import { showLoginRegister } from "./loginRegister.js";
-import { showJobs } from "./jobs.js";
+import { showTasks } from "./tasks.js";
 
 let registerDiv = null;
 let name = null;
@@ -24,11 +24,63 @@ export const handleRegister = () => {
   const registerButton = document.getElementById("register-button");
   const registerCancel = document.getElementById("register-cancel");
 
-  registerDiv.addEventListener("click", (e) => {
+  // registerDiv.addEventListener("click", (e) => {
+  //   if (inputEnabled && e.target.nodeName === "BUTTON") {
+  //     if (e.target === registerButton) {
+  //       showTasks();
+  //     } else if (e.target === registerCancel) {
+  //       showLoginRegister();
+  //     }
+  //   }
+  // });
+
+  registerDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === registerButton) {
-        showJobs();
+        if (password1.value != password2.value) {
+          message.textContent = "The passwords entered do not match.";
+        } else {
+          enableInput(false);
+
+          try {
+            const response = await fetch("/api/v1/auth/register", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                name: name.value,
+                email: email1.value,
+                password: password1.value,
+              }),
+            });
+
+            const data = await response.json();
+            if (response.status === 201) {
+              message.textContent = `Registration successful.  Welcome ${data.user.name}`;
+              setToken(data.token);
+
+              name.value = "";
+              email1.value = "";
+              password1.value = "";
+              password2.value = "";
+
+              showTasks();
+            } else {
+              message.textContent = data.msg;
+            }
+          } catch (err) {
+            console.error(err);
+            message.textContent = "A communications error occurred.";
+          }
+
+          enableInput(true);
+        }
       } else if (e.target === registerCancel) {
+        name.value = "";
+        email1.value = "";
+        password1.value = "";
+        password2.value = "";
         showLoginRegister();
       }
     }

--- a/public/tasks.js
+++ b/public/tasks.js
@@ -29,6 +29,9 @@ export const handleTasks = () => {
         message.textContent = "You have been logged off.";
         tasksTable.replaceChildren([tasksTableHeader]);
         showLoginRegister();
+      } else if (e.target.classList.contains("editButton")) {
+        message.textContent = "";
+        showAddEdit(e.target.dataset.id);
       }
     }
   });

--- a/public/tasks.js
+++ b/public/tasks.js
@@ -1,0 +1,36 @@
+import {
+  inputEnabled,
+  setDiv,
+  message,
+  setToken,
+  token,
+  enableInput,
+} from "./index.js";
+import { showLoginRegister } from "./loginRegister.js";
+import { showAddEdit } from "./addEdit.js";
+
+let tasksDiv = null;
+let tasksTable = null;
+let tasksTableHeader = null;
+
+export const handleTasks = () => {
+  tasksDiv = document.getElementById("tasks");
+  const logoff = document.getElementById("logoff");
+  const addTask = document.getElementById("add-task");
+  tasksTable = document.getElementById("tasks-table");
+  tasksTableHeader = document.getElementById("tasks-table-header");
+
+  tasksDiv.addEventListener("click", (e) => {
+    if (inputEnabled && e.target.nodeName === "BUTTON") {
+      if (e.target === addTask) {
+        showAddEdit(null);
+      } else if (e.target === logoff) {
+        showLoginRegister();
+      }
+    }
+  });
+};
+
+export const showTasks = async () => {
+  setDiv(tasksDiv);
+};

--- a/public/tasks.js
+++ b/public/tasks.js
@@ -25,12 +25,61 @@ export const handleTasks = () => {
       if (e.target === addTask) {
         showAddEdit(null);
       } else if (e.target === logoff) {
+        setToken(null);
+        message.textContent = "You have been logged off.";
+        tasksTable.replaceChildren([tasksTableHeader]);
         showLoginRegister();
       }
     }
   });
 };
 
+// export const showTasks = async () => {
+//   setDiv(tasksDiv);
+// };
+
 export const showTasks = async () => {
+  try {
+    enableInput(false);
+
+    const response = await fetch("/api/v1/tasks", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+    let children = [tasksTableHeader];
+
+    if (response.status === 200) {
+      if (data.count === 0) {
+        tasksTable.replaceChildren(...children); // clear this for safety
+      } else {
+        for (let i = 0; i < data.tasks.length; i++) {
+          let rowEntry = document.createElement("tr");
+
+          let editButton = `<td><button type="button" class="editButton" data-id=${data.tasks[i]._id}>edit</button></td>`;
+          let deleteButton = `<td><button type="button" class="deleteButton" data-id=${data.tasks[i]._id}>delete</button></td>`;
+          let rowHTML = `
+            <td>${data.tasks[i].title}</td>
+            <td>${data.tasks[i].status}</td>
+            <td>${data.tasks[i].recurrence}</td>
+            <div>${editButton}${deleteButton}</div>`;
+
+          rowEntry.innerHTML = rowHTML;
+          children.push(rowEntry);
+        }
+        tasksTable.replaceChildren(...children);
+      }
+    } else {
+      message.textContent = data.msg;
+    }
+  } catch (err) {
+    console.log(err);
+    message.textContent = "A communication error occurred.";
+  }
+  enableInput(true);
   setDiv(tasksDiv);
 };

--- a/public/tasks.js
+++ b/public/tasks.js
@@ -13,6 +13,7 @@ let tasksDiv = null;
 let tasksTable = null;
 let tasksTableHeader = null;
 
+// aka do this when a user clicks any button within the tasksDiv
 export const handleTasks = () => {
   tasksDiv = document.getElementById("tasks");
   const logoff = document.getElementById("logoff");
@@ -27,24 +28,27 @@ export const handleTasks = () => {
       } else if (e.target === logoff) {
         setToken(null);
         message.textContent = "You have been logged off.";
-        tasksTable.replaceChildren([tasksTableHeader]);
+        // tasksTable.replaceChildren([tasksTableHeader]);
+        tasksTable.replaceChildren(tasksTableHeader);
         showLoginRegister();
       } else if (e.target.classList.contains("editButton")) {
         message.textContent = "";
         showAddEdit(e.target.dataset.id);
+        // step 1 - handle clicks on the delete button
+      } else if (e.target.classList.contains("deleteButton")) {
+        message.textContent = "";
+        handleDelete(e.target.dataset.id);
       }
     }
   });
 };
 
-// export const showTasks = async () => {
-//   setDiv(tasksDiv);
-// };
-
+// used to GET and display tasks
 export const showTasks = async () => {
   try {
     enableInput(false);
 
+    // fetch tasks using the GET method
     const response = await fetch("/api/v1/tasks", {
       method: "GET",
       headers: {
@@ -53,7 +57,9 @@ export const showTasks = async () => {
       },
     });
 
+    // parse the raw response into usable js object
     const data = await response.json();
+    // create array called children that always has a header as the first element
     let children = [tasksTableHeader];
 
     if (response.status === 200) {
@@ -61,9 +67,11 @@ export const showTasks = async () => {
         tasksTable.replaceChildren(...children); // clear this for safety
       } else {
         for (let i = 0; i < data.tasks.length; i++) {
+          // create an empty table row that is ready to fill
           let rowEntry = document.createElement("tr");
 
           let editButton = `<td><button type="button" class="editButton" data-id=${data.tasks[i]._id}>edit</button></td>`;
+          // step 2 - create the actual delete button
           let deleteButton = `<td><button type="button" class="deleteButton" data-id=${data.tasks[i]._id}>delete</button></td>`;
           let rowHTML = `
             <td>${data.tasks[i].title}</td>
@@ -85,4 +93,32 @@ export const showTasks = async () => {
   }
   enableInput(true);
   setDiv(tasksDiv);
+};
+
+// step 3 - create the handleDelete function
+export const handleDelete = async (id) => {
+  try {
+    enableInput(false);
+
+    // delete task using DELETE method
+    const response = await fetch(`/api/v1/tasks/${id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    // if delete is successful do this
+    if (response.status === 200) {
+      message.textContent = "The task has been deleted.";
+      await showTasks();
+    } else {
+      message.textContent = data.msg;
+    }
+  } catch (err) {
+    console.log(err);
+    message.textContent = "Failed to delete task.";
+  }
+  enableInput(true);
 };


### PR DESCRIPTION
This PR wires up the front-end flows for the following:

-Register and Login
-Register/Login view switching
-Tasks list rendering and refresh
-Add Task (POST)
-Edit Task (PATCH)
-Delete Task (DELETE)
-Cancel edit and cancel add task
-Logoff by clearing token, resetting table, and returning back to register/login