### PR TITLE
Household signup: roles, join codes, and auto-create

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const taskRouter = require("./routes/tasks");
 const notFoundMiddleware = require("./middleware/not-found");
 const errorHandlerMiddleware = require("./middleware/error-handler");
 
+// security
 app.set("trust proxy", 1);
 app.use(
   rateLimiter({

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,12 +1,25 @@
 const User = require("../models/User");
+const Household = require("../models/Household");
 const { StatusCodes } = require("http-status-codes");
 const { BadRequestError, UnauthenticatedError } = require("../errors");
 
 const register = async (req, res) => {
   const user = await User.create({ ...req.body });
+  const household = await Household.create({
+    name: `${user.name}'s household`,
+    createdBy: user._id,
+  });
+  user.householdId = household._id;
+  user.role = "owner";
+  await user.save();
   const token = user.createJWT();
-  // const household
-  res.status(StatusCodes.CREATED).json({ user: { name: user.name }, token });
+  res
+    .status(StatusCodes.CREATED)
+    .json({
+      user: { name: user.name },
+      token,
+      household: { name: household.name, joinCode: household.joinCode },
+    });
 };
 
 const login = async (req, res) => {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -5,6 +5,7 @@ const { BadRequestError, UnauthenticatedError } = require("../errors");
 const register = async (req, res) => {
   const user = await User.create({ ...req.body });
   const token = user.createJWT();
+  // const household
   res.status(StatusCodes.CREATED).json({ user: { name: user.name }, token });
 };
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -4,22 +4,37 @@ const { StatusCodes } = require("http-status-codes");
 const { BadRequestError, UnauthenticatedError } = require("../errors");
 
 const register = async (req, res) => {
-  const user = await User.create({ ...req.body });
-  const household = await Household.create({
-    name: `${user.name}'s household`,
-    createdBy: user._id,
-  });
+  const { joinCode, ...userBody } = req.body;
+  const user = await User.create({ ...userBody });
+
+  let household = null;
+
+  // if there is a joinCode, try to find existing household, if found assign household to newly created user
+  // otherwise create household
+  if (joinCode) {
+    household = await Household.findOne({
+      joinCode: joinCode,
+    });
+    if (!household) {
+      throw new NotFoundError(`No household with joinCode ${joinCode}`);
+    }
+    user.role = "member";
+  } else {
+    household = await Household.create({
+      name: `${user.name}'s household`,
+      createdBy: user._id,
+    });
+    user.role = "owner";
+  }
+
   user.householdId = household._id;
-  user.role = "owner";
   await user.save();
   const token = user.createJWT();
-  res
-    .status(StatusCodes.CREATED)
-    .json({
-      user: { name: user.name },
-      token,
-      household: { name: household.name, joinCode: household.joinCode },
-    });
+  res.status(StatusCodes.CREATED).json({
+    user: { name: user.name },
+    token,
+    household: { name: household.name, joinCode: household.joinCode },
+  });
 };
 
 const login = async (req, res) => {

--- a/models/Household.js
+++ b/models/Household.js
@@ -2,11 +2,20 @@ const mongoose = require("mongoose");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 
+// generate the joinCode
+const genJoinCode = (len = 6) => {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ23456789";
+  return Array.from(
+    { length: len },
+    () => alphabet[Math.floor(Math.random() * alphabet.length)]
+  ).join("");
+};
+
 const HouseholdSchema = new mongoose.Schema(
   {
     name: {
       type: String,
-      required: [true, "Please provide household title"],
+      required: [true, "Please provide household name"],
       maxlength: 100,
       trim: true,
     },
@@ -16,10 +25,23 @@ const HouseholdSchema = new mongoose.Schema(
       required: true,
       immutable: true,
     },
+    joinCode: {
+      type: String,
+      required: true,
+      unique: true,
+      uppercase: true,
+      trim: true,
+    },
   },
   // timestamps: true adds createdAt and updatedAt to the schema
   { timestamps: true }
 );
+
+HouseholdSchema.pre("validate", function () {
+  if (!this.joinCode) this.joinCode = genCode(6);
+});
+
+module.exports = mongoose.model("Household", HouseholdSchema);
 
 // Add ownerId and joinCode
 // Should it be createdBy or createdAt??

--- a/models/Household.js
+++ b/models/Household.js
@@ -33,7 +33,6 @@ const HouseholdSchema = new mongoose.Schema(
       trim: true,
     },
   },
-  // timestamps: true adds createdAt and updatedAt to the schema
   { timestamps: true }
 );
 
@@ -43,9 +42,9 @@ HouseholdSchema.pre("validate", function () {
 
 module.exports = mongoose.model("Household", HouseholdSchema);
 
-// Add ownerId and joinCode
+// Add ownerId
+// Add joinCode
 // Should it be createdBy or createdAt??
 // Should I add ownerId for the user that creates the Household? How is that diff from createdBy?
-// Research Join Codes
 // How to implement this? New user creates new household || New user joins existing household with join code
 // Bigger Picture: Can existing user join multiple households? Can existing user create multiple households?

--- a/models/Household.js
+++ b/models/Household.js
@@ -38,7 +38,7 @@ const HouseholdSchema = new mongoose.Schema(
 );
 
 HouseholdSchema.pre("validate", function () {
-  if (!this.joinCode) this.joinCode = genCode(6);
+  if (!this.joinCode) this.joinCode = genJoinCode(6);
 });
 
 module.exports = mongoose.model("Household", HouseholdSchema);

--- a/models/Household.js
+++ b/models/Household.js
@@ -4,7 +4,7 @@ const jwt = require("jsonwebtoken");
 
 const HouseholdSchema = new mongoose.Schema(
   {
-    title: {
+    name: {
       type: String,
       required: [true, "Please provide household title"],
       maxlength: 100,
@@ -21,6 +21,9 @@ const HouseholdSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+// Add ownerId and joinCode
+// Should it be createdBy or createdAt??
+// Should I add ownerId for the user that creates the Household? How is that diff from createdBy?
 // Research Join Codes
 // How to implement this? New user creates new household || New user joins existing household with join code
 // Bigger Picture: Can existing user join multiple households? Can existing user create multiple households?

--- a/models/User.js
+++ b/models/User.js
@@ -26,6 +26,16 @@ const UserSchema = new mongoose.Schema({
     required: [true, "Please provide password"],
     minlength: [6, "Passwords need to be at least 6 characters"],
   },
+  householdId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Household",
+    default: null,
+  },
+  role: {
+    type: String,
+    enum: ["owner", "member"],
+    default: "member",
+  },
 });
 
 // createdAt??

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,34 @@
           <label for="password2">verify password:</label>
           <input type="password" id="password2" />
         </div>
+        <div>
+          <label for="createHousehold">Create New Household</label>
+          <input
+            id="createHousehold"
+            type="radio"
+            name="household"
+            value="createHousehold"
+            checked
+          />
+          <br>
+          <label for="joinHousehold">Join Existing Household</label>
+          <input
+            id="joinHousehold"
+            type="radio"
+            name="household"
+            value="joinHousehold"
+          />
+        </div>
+        <div id="joinHouseholdTextContainer" hidden>       
+          <label
+          for="joinHouseholdText">Household Code</lable>
+          <input
+          type="text"
+          id="joinHouseholdText"
+          name="joinHouseholdText"
+          placeholder="e.g. SIXDIG"
+        />
+      </div>
         <button type="button" id="register-button">register</button>
         <button type="button" id="register-cancel">cancel</button>
       </form>

--- a/public/register.js
+++ b/public/register.js
@@ -24,6 +24,13 @@ export const handleRegister = () => {
   const registerButton = document.getElementById("register-button");
   const registerCancel = document.getElementById("register-cancel");
 
+  const createHousehold = document.getElementById("createHousehold");
+  const joinHousehold = document.getElementById("joinHousehold");
+  const joinHouseholdText = document.getElementById("joinHouseholdText");
+  const joinHouseholdTextContainer = document.getElementById(
+    "joinHouseholdTextContainer"
+  );
+
   registerDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === registerButton) {

--- a/public/register.js
+++ b/public/register.js
@@ -24,12 +24,21 @@ export const handleRegister = () => {
   const registerButton = document.getElementById("register-button");
   const registerCancel = document.getElementById("register-cancel");
 
-  const createHousehold = document.getElementById("createHousehold");
-  const joinHousehold = document.getElementById("joinHousehold");
+  const radios = document.querySelectorAll("input[name='household']");
   const joinHouseholdText = document.getElementById("joinHouseholdText");
   const joinHouseholdTextContainer = document.getElementById(
     "joinHouseholdTextContainer"
   );
+  radios.forEach((radio) => {
+    radio.addEventListener("change", (e) => {
+      const value = e.target.value;
+      if (value === "createHousehold") {
+        joinHouseholdTextContainer.hidden = true;
+      } else {
+        joinHouseholdTextContainer.hidden = false;
+      }
+    });
+  });
 
   registerDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {

--- a/public/register.js
+++ b/public/register.js
@@ -24,16 +24,6 @@ export const handleRegister = () => {
   const registerButton = document.getElementById("register-button");
   const registerCancel = document.getElementById("register-cancel");
 
-  // registerDiv.addEventListener("click", (e) => {
-  //   if (inputEnabled && e.target.nodeName === "BUTTON") {
-  //     if (e.target === registerButton) {
-  //       showTasks();
-  //     } else if (e.target === registerCancel) {
-  //       showLoginRegister();
-  //     }
-  //   }
-  // });
-
   registerDiv.addEventListener("click", async (e) => {
     if (inputEnabled && e.target.nodeName === "BUTTON") {
       if (e.target === registerButton) {

--- a/public/register.js
+++ b/public/register.js
@@ -14,6 +14,7 @@ let name = null;
 let email1 = null;
 let password1 = null;
 let password2 = null;
+let joinHouseholdText = null;
 
 export const handleRegister = () => {
   registerDiv = document.getElementById("register-div");
@@ -21,11 +22,11 @@ export const handleRegister = () => {
   email1 = document.getElementById("email1");
   password1 = document.getElementById("password1");
   password2 = document.getElementById("password2");
+  joinHouseholdText = document.getElementById("joinHouseholdText");
   const registerButton = document.getElementById("register-button");
   const registerCancel = document.getElementById("register-cancel");
 
   const radios = document.querySelectorAll("input[name='household']");
-  const joinHouseholdText = document.getElementById("joinHouseholdText");
   const joinHouseholdTextContainer = document.getElementById(
     "joinHouseholdTextContainer"
   );
@@ -58,6 +59,7 @@ export const handleRegister = () => {
                 name: name.value,
                 email: email1.value,
                 password: password1.value,
+                joinCode: joinHouseholdText.value,
               }),
             });
 
@@ -70,6 +72,7 @@ export const handleRegister = () => {
               email1.value = "";
               password1.value = "";
               password2.value = "";
+              joinHouseholdText.value = "";
 
               showTasks();
             } else {
@@ -87,6 +90,7 @@ export const handleRegister = () => {
         email1.value = "";
         password1.value = "";
         password2.value = "";
+        joinHouseholdText.value = "";
         showLoginRegister();
       }
     }
@@ -97,5 +101,6 @@ export const showRegister = () => {
   email1.value = null;
   password1.value = null;
   password2.value = null;
+  joinHouseholdText.value = null;
   setDiv(registerDiv);
 };


### PR DESCRIPTION
This PR adds a household flow at registration. A user can join an existing household by joinCode or auto-create a new household. This sets the role as "owner" or "member", links the household, and returns JWT and household info.

-User model: add householdId: ObjectId and role: ["owner", "member"].
-Household model: add pre-validate hook to set joinCode = genJoinCode() when absent.
-Register: join via joinCode and role=member, or create new household and role=owner. Then link household, return JWT and return name and joinCode.
-UI: add hide/show radio toggle for "Join Existing Household" and "Create New Household" fields.